### PR TITLE
fix: accurately explain the differences between var and let

### DIFF
--- a/learn-basic-javascript-by-building-a-role-playing-game/index040.js
+++ b/learn-basic-javascript-by-building-a-role-playing-game/index040.js
@@ -5,7 +5,7 @@ var currentWeapon = 0;
 
 /*
 We've been declaring variables with the 'var' keyword.
-This makes a variable available everywhere.
-But it's better to scope variable as narrowly as possible.
-Change every 'var' in the code to 'let' so that the variables have local scope instead of global scope.
+However, in modern JavaScript, it's better to use 'const' or 'let' instead, because they fix a number of unusual behaviors with 'var' that make it difficult to reason about.
+'const' signals that a variable can only be assigned once, and 'let' signals that we want to reassign it.
+Because we will be changing these values as the game progressive, let's use 'let' for all of them.
 */

--- a/learn-basic-javascript-by-building-a-role-playing-game/index040.js
+++ b/learn-basic-javascript-by-building-a-role-playing-game/index040.js
@@ -4,8 +4,5 @@ var gold = 50;
 var currentWeapon = 0;
 
 /*
-We've been declaring variables with the 'var' keyword.
-However, in modern JavaScript, it's better to use 'const' or 'let' instead, because they fix a number of unusual behaviors with 'var' that make it difficult to reason about.
-'const' signals that a variable can only be assigned once, and 'let' signals that we want to reassign it.
-Because we will be changing these values as the game progresses, let's use 'let' for all of them.
+We've been declaring variables with the `var` keyword. However, in modern JavaScript, it's better to use `let` instead of `var` because it fixes a number of unusual behaviors with 'var' that make it difficult to reason about. Change every `var` to `let`.
 */

--- a/learn-basic-javascript-by-building-a-role-playing-game/index040.js
+++ b/learn-basic-javascript-by-building-a-role-playing-game/index040.js
@@ -7,5 +7,5 @@ var currentWeapon = 0;
 We've been declaring variables with the 'var' keyword.
 However, in modern JavaScript, it's better to use 'const' or 'let' instead, because they fix a number of unusual behaviors with 'var' that make it difficult to reason about.
 'const' signals that a variable can only be assigned once, and 'let' signals that we want to reassign it.
-Because we will be changing these values as the game progressive, let's use 'let' for all of them.
+Because we will be changing these values as the game progresses, let's use 'let' for all of them.
 */


### PR DESCRIPTION
If declared at the top level, `var` and `let` _both_ create global variables. The difference is that within a block that isn't a function body, `let` will be in the block scope, whereas `var` will be in the parent scope.

As we're at the top level here, the explanation needs to be changed to make sense.

Not sure if my suggested edit is all that informative --- perhaps could be improved further by adding more info or a link? Is linking to external resources encouraged or not?