### PR TITLE
fix(a11y): add song title to delete button's accessible name

### DIFF
--- a/javascript-algorithms-and-data-structures/learn-basic-string-and-array-methods-by-building-a-music-player-app/script.js
+++ b/javascript-algorithms-and-data-structures/learn-basic-string-and-array-methods-by-building-a-music-player-app/script.js
@@ -117,7 +117,7 @@ function renderSongs(array) {
                       <p>${song.duration}</p>
                   </div>
               </button>
-              <button class="playlist-song-delete" aria-label="delete">
+              <button class="playlist-song-delete" aria-label="delete ${song.title}">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <circle id="delete-Btn" cx="8" cy="8" r="8" fill="#4d4d62"/>
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M5.32587 5.18571C5.7107 4.90301 6.28333 4.94814 6.60485 5.28651L8 6.75478L9.39515 5.28651C9.71667 4.94814 10.2893 4.90301 10.6741 5.18571C11.059 5.4684 11.1103 5.97188 10.7888 6.31026L9.1832 7.99999L10.7888 9.68974C11.1103 10.0281 11.059 10.5316 10.6741 10.8143C10.2893 11.097 9.71667 11.0519 9.39515 10.7135L8 9.24521L6.60485 10.7135C6.28333 11.0519 5.7107 11.097 5.32587 10.8143C4.94102 10.5316 4.88969 10.0281 5.21121 9.68974L6.8168 7.99999L5.21122 6.31026C4.8897 5.97188 4.94102 5.4684 5.32587 5.18571Z" fill="white"/>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The accessible name for the song's delete button should contain the name of the song so that there is no confusion for screen reader users as to which song will be deleted.