### PR TITLE
fix: revert dynamic music player focus

### DIFF
--- a/javascript-algorithms-and-data-structures/learn-basic-string-and-array-methods-by-building-a-music-player-app/script.js
+++ b/javascript-algorithms-and-data-structures/learn-basic-string-and-array-methods-by-building-a-music-player-app/script.js
@@ -223,14 +223,7 @@ const highlightCurrentSong = () => {
     songEl.removeAttribute("aria-current");
   });
 
-  if (songToHighlight) {
-    // Teach how to query specific inner elements within a node
-    const songButton = songToHighlight.querySelector(
-      "button.playlist-song-info"
-    );
-    songToHighlight.setAttribute("aria-current", "true");
-    songButton.focus();
-  }
+  if (songToHighlight) songToHighlight.setAttribute("aria-current", "true");
 };
 
 const renderSongs = (array) => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR reverts the changes from [this commit](https://github.com/freeCodeCamp/CurriculumExpansion/pull/349/commits/c905f540d5a01114a2b5fe0774cbf3c90966004a) because changes to focus should generally be initiated by user actions.

More details from @bbsmooth in this comment: https://github.com/freeCodeCamp/CurriculumExpansion/pull/349#issuecomment-1769875081