### PR TITLE
fix: update useMemo useCallback search app to shopping list

### DIFF
--- a/fullstack-cert/react-projects/search-app/index.html
+++ b/fullstack-cert/react-projects/search-app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Search App</title>
+    <title>Shopping List</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.development.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.development.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.5/babel.min.js"></script>
@@ -24,10 +24,10 @@
       data-presets="react"
       data-type="module"
     >
-      import { SearchApp } from "./index.jsx";
+      import { ShoppingList } from "./index.jsx";
       const appContainer = document.getElementById("app-container");
       const root = ReactDOM.createRoot(appContainer); // createRoot(container!) if you use TypeScript
-      root.render(<SearchApp />);
+      root.render(<ShoppingList />);
     </script>
   </body>
 </html>

--- a/fullstack-cert/react-projects/search-app/index.jsx
+++ b/fullstack-cert/react-projects/search-app/index.jsx
@@ -1,66 +1,72 @@
 const { useState, useMemo, useCallback } = React; // See if we can convert to import statements on Learn
 
 const items = [
-  "Apple",
-  "Banana",
-  "Orange",
-  "Grape",
-  "Mango",
+  "Apples",
+  "Bananas",
+  "Strawberries",
+  "Blueberries",
+  "Mangoes",
   "Pineapple",
-  "Strawberry",
-  "Blueberry",
+  "Lettuce",
+  "Broccoli",
+  "Paper Towels",
+  "Dish Soap",
 ];
 
-// Global variable to track `selectItem` across renders
-let prevSelectItem = null;
+// Global variable to track `toggleItem` across renders
+let prevToggleItem = null;
 
-export const SearchApp = () => {
+export const ShoppingList = () => {
   const [query, setQuery] = useState("");
-  const [selectedItem, setSelectedItem] = useState(null);
+  const [selectedItems, setSelectedItems] = useState([]);
 
   // // Unoptimized filtering (runs on every render)
   // console.log("Filtering items...");
-  // const filteredItems = items.filter((item) => {
-  //   return item.toLowerCase().includes(query.toLowerCase());
-  // });
+  // const filteredItems = items.filter((item) =>
+  //   item.toLowerCase().includes(query.toLowerCase())
+  // );
 
   // Optimized filtering (only runs when `query` changes)
   const filteredItems = useMemo(() => {
     console.log("Filtering items...");
-    return items.filter((item) => {
-      return item.toLowerCase().includes(query.toLowerCase());
-    });
+    return items.filter((item) =>
+      item.toLowerCase().includes(query.toLowerCase())
+    );
   }, [query]);
 
   // // Unoptimized event handler (new function created and used on every render)
-  // const selectItem = (item) => {
-  //   console.log(`Selecting: ${item}`);
-  //   setSelectedItem(item);
+  // const toggleItem = (item) => {
+  //   setSelectedItems((prev) =>
+  //     prev.includes(item) ? prev.filter((i) => i !== item) : [...prev, item]
+  //   );
   // };
+
+  // console.log("New toggleItem function created");
 
   // Optimized event handler function (according to the React docs, React will always create)
   // a new function, but `useCallback` will try to use a cached function reference whenever
   // possible
-  const selectItem = useCallback(
+  const toggleItem = useCallback(
     (item) => {
-      // console.log(`Selecting: ${item}`); // Can be removed / commented out in workshop step
-      setSelectedItem(item);
+      setSelectedItems((prev) =>
+        prev.includes(item) ? prev.filter((i) => i !== item) : [...prev, item]
+      );
     },
-    [selectedItem]
+    [setSelectedItems]
   );
 
-  // Logging to show when a new `selectItem` function
+  // Logging to show when a new `toggleItem` function
   // is used
-  if (prevSelectItem !== selectItem) {
-    console.log("New selectItem function");
-    prevSelectItem = selectItem; // Update for next render
+  if (prevToggleItem !== toggleItem) {
+    console.log("New toggleItem function");
+    prevToggleItem = toggleItem; // Update for next render
   } else {
-    console.log("Current selectItem function");
+    console.log("Current toggleItem function");
   }
 
   return (
     <div className="container">
-      <h1>Search App</h1>
+      <h1>Shopping List</h1>
       <form>
         <label htmlFor="search">Search for an item:</label>
         <input
@@ -73,22 +79,25 @@ export const SearchApp = () => {
         />
         <p id="search-description">Type to filter the list below.</p>
         <ul>
-          {filteredItems.map((item) => (
-            <li key={item}>
-              {item} -{" "}
-              <button
-                type="button"
-                onClick={() => selectItem(item)}
-                aria-label={`Select ${item}`}
+          {filteredItems.map((item) => {
+            const isChecked = selectedItems.includes(item);
+            return (
+              <li
+                key={item}
+                style={{ textDecoration: isChecked ? "line-through" : "none" }}
               >
-                Select
-              </button>
-            </li>
-          ))}
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={isChecked}
+                    onChange={() => toggleItem(item)}
+                  />
+                  {item}
+                </label>
+              </li>
+            );
+          })}
         </ul>
-        <p className="selected-item">
-          {selectedItem ? `Selected: ${selectedItem}` : "No item selected"}
-        </p>
       </form>
     </div>
   );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
After looking more at the `useEffect` Live Search project, the current `useMemo` and `useCallback` search app felt too similar in concept.

This PR updates the current `useMemo` and `useCallback` workshop project to a simple shopping list, similar to a todo list with a predefined list of groceries.

The main changes to the project are:
- Buttons are replaced by checkboxes
- We now track a list of items to see if something is checked or not
- Previous and current state are compared in the event handler function, now called `toggleItem`
- There's some dynamic styling for adding a strikethrough for selected / checked items

Otherwise, the project is largely the same, and it shouldn't take long to update the current workshop steps I've created for the main repo.