### PR TITLE
feat: add medical data validator (dictionary and sets workshop)

### DIFF
--- a/fullstack-cert/python-projects/medical-data-validator-workshop/main.py
+++ b/fullstack-cert/python-projects/medical-data-validator-workshop/main.py
@@ -1,0 +1,82 @@
+import re
+
+medical_records = [
+    {
+        "patient_id": "P1001",
+        "age": 34,
+        "gender": "Female",
+        "diagnosis": "Hypertension",
+        "medications": ["Lisinopril"],
+        "last_visit_id": "V2301",
+    },
+    {
+        "patient_id": "P1002",
+        "age": 47,
+        "gender": "Male",
+        "diagnosis": "Type 2 Diabetes",
+        "medications": ["Metformin", "Insulin"],
+        "last_visit_id": "V2302",
+    },
+    {
+        "patient_id": "P1003",
+        "age": 29,
+        "gender": "Female",
+        "diagnosis": "Asthma",
+        "medications": ["Albuterol"],
+        "last_visit_id": "V2303",
+    },
+    {
+        "patient_id": "P1004",
+        "age": 56,
+        "gender": "Male",
+        "diagnosis": "Chronic Back Pain",
+        "medications": ["Ibuprofen", "Physical Therapy"],
+        "last_visit_id": "V2304",
+    },
+]
+
+
+def check_values(patient_id, age, gender, diagnosis, medications, last_visit_id):
+
+    constraints = {
+        "patient_id": isinstance(patient_id, str) and re.fullmatch(r"P\d+", patient_id),
+        "age": isinstance(age, int) and age >= 18,
+        "gender": isinstance(gender, str) and gender.lower() in ("male", "female"),
+        "diagnosis": isinstance(diagnosis, str) or diagnosis is None,
+        "medications": isinstance(medications, list)
+        and all(isinstance(i, str) for i in medications),
+        "last_visit_id": isinstance(last_visit_id, str)
+        and re.fullmatch(r"V\d+", last_visit_id),
+    }
+
+    return {key: value for key, value in constraints.items() if not value}
+
+
+def validate(data):
+    is_list_of_dicts = isinstance(data, list) and all(isinstance(i, dict) for i in data)
+
+    if not is_list_of_dicts:
+        return "Invalid format: expected a list of dictionaries."
+
+    key_set = set(
+        ["patient_id", "age", "gender", "diagnosis", "medications", "last_visit_id"]
+    )
+
+    for index, dictionary in enumerate(data):
+        if set(dictionary.keys()) != key_set:
+            print(
+                f"Invalid format: {dictionary} at position {index} has missing and/or invalid keys."
+            )
+            return False
+        invalid_records = check_values(**dictionary)
+        for key in invalid_records.keys():
+            print(
+                f"Unexpected format '{key}: {dictionary.get(key)}' at position {index}."
+            )
+            return False
+
+    print("Valid format.")
+    return True
+
+
+validate(medical_records)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #693

<!-- Feel free to add any additional description of changes below this line -->

The idea here is to provide a set of data in the form of a list of dictionaries (where each dictionary represents a patient) and require to validate the data checking both the general structure and that the key-value pairs of each dictionary follow the desired pattern.

I used a dictionary comprehension, which we can teach directly here without including it in the lecture IMO.

Also, I used a couple of regular expressions, nothing fancy. The standard library is introduced just before this workshop so it should be fine.


