### PR TITLE
chore: ignore parcel dependencies globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
-mongodb-movie-review-db/node_modules
+# Libraries 
+node_modules/
+
+# Parcel projects
+.parcel-cache/
+
+# Build Output
+dist/
 
 .DS_Store


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Seeing as how the MongoDB movie review project is no longer the only prototype that uses node_modules; I thought it would be best to remove that dependency specifically and focus on all node_modules folders collectively. 

I also added ignore content specifically based on Parcel which is currently used by the Typescript projects. 
