### PR TITLE
feat: Add more complete user stories

### DIFF
--- a/fullstack-cert/typescript-projects/interface-and-types-lab/user-stories.md
+++ b/fullstack-cert/typescript-projects/interface-and-types-lab/user-stories.md
@@ -1,18 +1,31 @@
 # User Stories
 In this lab, you will build a MotoShop - electronic motorcycle market.
 
-- You should define a `Category` type that only allows the string values `""Sport"`, `"Crusier"` , `"Touring"`, `"Dirt"`, `"Adventure"`, `"Naked"` and `"Electric"`. 
+- You should define a `Category` type that only allows the string values `""Sport"`, `"Cruiser"` , `"Touring"`, `"Dirt"`, `"Adventure"`, `"Naked"` and `"Electric"`.
 - You should define `Motorcycle` type or interface that includes the following required properties:
- `id`, `name`, `manufactorer`, `category`, `price`, `image_url`, `description`, `year`, `engine_cc`, `created_at`. 
-- All properties of the `Motorcycle` type except `category`, should use primitive TypeScript types (`string` or `number`).
-- The `category` property should use the `Category` type.
+ `id`, `name`, `manufacturer`, `category`, `price`, `image_url`, `description`, `year`, `engine_cc`, `created_at`.
+  - The `category` property should use the `Category` type.
 - You should create a function named `fetchMotorcycles` that returns a `Promise` resolving to an array of `Motorcycle` objects.
 
 - The `fetchMotorcycles` function should load motorcycle data from the following URL:  
   `https://cdn.freecodecamp.org/curriculum/labs/data/motorcycles.json`
 
-- The `fetchMotorcycles` function should ensure the returned value is typed as `Motorcycle[]`.
+- The `fetchMotorcycles` function should ensure the returned value is typed as `Motorcycle[]`. Each Motorcycle should be sorted
+  by `created_at` in ascending order.
 
-- You should create a function named `renderMotorcycleCard` that takes a single `Motorcycle` object as a parameter and returns a string containing the HTML for that motorcycle card.
+- You should create a function named `renderMotorcycleCard` that takes a single `Motorcycle` object as a parameter and returns a string containing the HTML that contains a formatted HTML string for the motorcycle card.
+  - Each motorcycle card component should have an `img` element with a valid image and have the id of `motorcycle-card-image`.
 
-- You should create a function named `renderMotorcycleGrid` that takes an array of `Motorcycle` objects and renders them inside the element with id `motorcycle-grid`.
+  - Each motorcycle card component should have an element with an id of `year-badge` listing the year in plain text.
+
+  - Each motorcycle card component should have an element with an id of `motorcycle-name` containing the name of the motorcycle.
+
+  - Each motorcycle card component should have an element with an id of `motorcycle-manufacturer` containing a description of the  motorcycle.
+
+  - Each motorcycle card component should have an element with an id of `engine` and list the engine.
+
+- You should create a function named `renderMotorcycleGrid` that takes an array of `Motorcycle` objects and renders the equivalent motorcycle card component inside the element with id `motorcycle-grid`.
+
+- The `Motorcycle` elements inside of the grid can be filtered by name using an element with an id of `filter`. 
+
+- The number of `Motorcycle` elements that are displayed should be listed inside of an element with an id of `results-number`.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/CurriculumExpansion/issues/1063 

<!-- Feel free to add any additional description of changes below this line -->
The stories I added feel more like the kinds of the things that would be used for tests rather than as the user stories that would display at the top of the challenge. But campers also kind of need to know these things so that they can complete the challenge.

I also need to modify the solution code. I want to change the selectors from using `class` to using `id` since it seems more reliable to me. 